### PR TITLE
WIP: Fix #106 positionnement dans les grands chenaux

### DIFF
--- a/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/Chenaux.java
+++ b/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/Chenaux.java
@@ -4,9 +4,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.arig.robot.utils.ArigCollectionUtils;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -53,31 +50,5 @@ public abstract class Chenaux {
         copy.chenalRouge.addAll(chenalRouge);
         copy.chenalVert.addAll(chenalVert);
         return copy;
-    }
-
-    public void writeStatus(ObjectOutputStream os) throws IOException {
-        os.writeByte(chenalVert.size());
-        for (ECouleurBouee bouee : chenalVert) {
-            os.writeByte(bouee.ordinal());
-        }
-
-        os.writeByte(chenalRouge.size());
-        for (ECouleurBouee bouee : chenalRouge) {
-            os.writeByte(bouee.ordinal());
-        }
-    }
-
-    public void readStatus(ObjectInputStream is) throws IOException {
-        chenalVert.clear();
-        byte nbVert = is.readByte();
-        for (byte i = 0; i < nbVert; i++) {
-            chenalVert.add(ECouleurBouee.values()[is.readByte()]);
-        }
-
-        chenalRouge.clear();
-        byte nbRouge = is.readByte();
-        for (byte i = 0; i < nbRouge; i++) {
-            chenalRouge.add(ECouleurBouee.values()[is.readByte()]);
-        }
     }
 }

--- a/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/ECouleurBouee.java
+++ b/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/ECouleurBouee.java
@@ -3,6 +3,7 @@ package org.arig.robot.model;
 import java.util.function.Predicate;
 
 public enum ECouleurBouee {
+    NULL,
     ROUGE,
     VERT,
     INCONNU;

--- a/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/EurobotStatus.java
+++ b/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/EurobotStatus.java
@@ -162,12 +162,12 @@ public class EurobotStatus extends AbstractRobotStatus {
         return grandChenaux.chenalRougeEmpty();
     }
 
-    public void deposeGrandChenalVert(ECouleurBouee... bouees) {
-        grandChenaux.addVert(bouees);
+    public void deposeGrandChenalVert(GrandChenaux.Line line, ECouleurBouee... bouees) {
+        grandChenaux.addVert(line, bouees);
     }
 
-    public void deposeGrandChenalRouge(ECouleurBouee... bouees) {
-        grandChenaux.addRouge(bouees);
+    public void deposeGrandChenalRouge(GrandChenaux.Line line, ECouleurBouee... bouees) {
+        grandChenaux.addRouge(line, bouees);
     }
 
     public Chenaux cloneGrandChenaux() {

--- a/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/GrandChenaux.java
+++ b/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/model/GrandChenaux.java
@@ -2,12 +2,55 @@ package org.arig.robot.model;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.util.Assert;
+
+import java.util.Objects;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class GrandChenaux extends Chenaux {
+
+    public enum Line {
+        A, B
+    }
+
+    // un chenal contient 9 emplacements sur deux lignes de 5 et 4, en quinconce
+    // il est possible d'en mettre plus que 9, qui n'auront pas de position connue
+
     @Override
     protected Chenaux newInstance() {
-        return new GrandChenaux();
+        GrandChenaux chenaux = new GrandChenaux();
+        for (int i = 0; i < 9; i++) {
+            chenaux.chenalRouge.set(i, null);
+            chenaux.chenalVert.set(i, null);
+        }
+        return chenaux;
     }
+
+    @Override
+    public boolean chenalVertEmpty() {
+        return chenalVert.stream().allMatch(Objects::isNull);
+    }
+
+    @Override
+    public boolean chenalRougeEmpty() {
+        return chenalRouge.stream().allMatch(Objects::isNull);
+    }
+
+    public void addRouge(Line line, ECouleurBouee... bouees) {
+        for (int i = 0; i < bouees.length; i++) {
+            if (bouees[i] != null) {
+                chenalRouge.set(i + (line == Line.A ? 0 : 5), bouees[i]);
+            }
+        }
+    }
+
+    public void addVert(Line line, ECouleurBouee... bouees) {
+        for (int i = 0; i < bouees.length; i++) {
+            if (bouees[i] != null) {
+                chenalVert.set(i + (line == Line.A ? 0 : 5), bouees[i]);
+            }
+        }
+    }
+
 }

--- a/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/services/RobotGroupService.java
+++ b/eurobot-system-lib-parent/eurobot-system-lib-core/src/main/java/org/arig/robot/services/RobotGroupService.java
@@ -7,6 +7,7 @@ import org.arig.robot.model.EPort;
 import org.arig.robot.model.EStatusEvent;
 import org.arig.robot.model.ETeam;
 import org.arig.robot.model.EurobotStatus;
+import org.arig.robot.model.GrandChenaux;
 import org.arig.robot.model.Point;
 import org.arig.robot.model.communication.balise.enums.EDirectionGirouette;
 import org.arig.robot.system.group.IRobotGroup;
@@ -98,10 +99,10 @@ public class RobotGroupService implements InitializingBean, IRobotGroup.Handler 
                 rs.deposePetitPort(getBouees(value));
                 break;
             case DEPOSE_GRAND_CHENAL_ROUGE:
-                rs.deposeGrandChenalRouge(getBouees(value));
+                rs.deposeGrandChenalRouge(GrandChenaux.Line.values()[value[0]], getBouees(value, 1));
                 break;
             case DEPOSE_GRAND_CHENAL_VERT:
-                rs.deposeGrandChenalVert(getBouees(value));
+                rs.deposeGrandChenalVert(GrandChenaux.Line.values()[value[0]], getBouees(value, 1));
                 break;
             case DEPOSE_PETIT_CHENAL_ROUGE:
                 rs.deposePetitChenalRouge(getBouees(value));
@@ -123,9 +124,14 @@ public class RobotGroupService implements InitializingBean, IRobotGroup.Handler 
     }
 
     private ECouleurBouee[] getBouees(byte[] value) {
+        return getBouees(value, 0);
+    }
+
+    private ECouleurBouee[] getBouees(byte[] value, int start) {
         ECouleurBouee[] bouees = new ECouleurBouee[value.length];
-        for (int i = 0; i < value.length; i++) {
-            bouees[i] = ECouleurBouee.values()[value[i]];
+        for (int i = start; i < value.length; i++) {
+            ECouleurBouee bouee = ECouleurBouee.values()[value[i]];
+            bouees[i] = bouee == ECouleurBouee.NULL ? null : bouee;
         }
         return bouees;
     }
@@ -203,14 +209,14 @@ public class RobotGroupService implements InitializingBean, IRobotGroup.Handler 
         sendEventBouees(EStatusEvent.DEPOSE_PETIT_PORT, bouees);
     }
 
-    public void deposeGrandChenalVert(ECouleurBouee... bouees) {
-        rs.deposeGrandChenalVert(bouees);
-        sendEventBouees(EStatusEvent.DEPOSE_GRAND_CHENAL_VERT, bouees);
+    public void deposeGrandChenalVert(GrandChenaux.Line line, ECouleurBouee... bouees) {
+        rs.deposeGrandChenalVert(line, bouees);
+        sendEventGrandChenal(EStatusEvent.DEPOSE_GRAND_CHENAL_VERT, line, bouees);
     }
 
-    public void deposeGrandChenalRouge(ECouleurBouee... bouees) {
-        rs.deposeGrandChenalRouge(bouees);
-        sendEventBouees(EStatusEvent.DEPOSE_GRAND_CHENAL_ROUGE, bouees);
+    public void deposeGrandChenalRouge(GrandChenaux.Line line, ECouleurBouee... bouees) {
+        rs.deposeGrandChenalRouge(line, bouees);
+        sendEventGrandChenal(EStatusEvent.DEPOSE_GRAND_CHENAL_ROUGE, line, bouees);
     }
 
     public void deposePetitChenalVert(ECouleurBouee... bouees) {
@@ -245,6 +251,17 @@ public class RobotGroupService implements InitializingBean, IRobotGroup.Handler 
             data[3 + i * 3] = (byte) Math.round(hautFond.get(i).pt().getY() / 10.0);
         }
         sendEvent(EStatusEvent.HAUT_FOND, data);
+    }
+
+    private void sendEventGrandChenal(EStatusEvent event, GrandChenaux.Line line, ECouleurBouee... bouees) {
+        byte[] data = new byte[1 + bouees.length];
+        data[0] = (byte) line.ordinal();
+        for (int i = 0; i < bouees.length; i++) {
+            if (bouees[i] != null) {
+                data[i + 1] = (byte) bouees[i].ordinal();
+            }
+        }
+        sendEvent(event, data);
     }
 
     private void sendEventBouees(EStatusEvent event, ECouleurBouee[] bouees) {

--- a/nerell-parent/nerell-common/src/main/java/org/arig/robot/services/AbstractNerellPincesArriereService.java
+++ b/nerell-parent/nerell-common/src/main/java/org/arig/robot/services/AbstractNerellPincesArriereService.java
@@ -3,6 +3,7 @@ package org.arig.robot.services;
 import lombok.extern.slf4j.Slf4j;
 import org.arig.robot.constants.IConstantesServosNerell;
 import org.arig.robot.model.ECouleurBouee;
+import org.arig.robot.model.GrandChenaux;
 import org.arig.robot.model.NerellRobotStatus;
 import org.arig.robot.utils.ThreadUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,25 +73,28 @@ public abstract class AbstractNerellPincesArriereService implements INerellPince
         if (partielle) {
             deposeTable(couleurChenal);
 
-            for (int i = 0; i < rs.pincesArriere().length; i++) {
+            ECouleurBouee[] boueesPosees = new ECouleurBouee[]{null, null, null, null, null};
+            for (int i = 0; i < 5; i++) {
                 final ECouleurBouee couleurPince = rs.pincesArriere()[i];
                 if (couleurPince == couleurChenal || couleurPince == ECouleurBouee.INCONNU) {
-                    if (couleurChenal == ECouleurBouee.ROUGE) {
-                        group.deposeGrandChenalRouge(couleurPince);
-                    } else {
-                        group.deposeGrandChenalVert(couleurPince);
-                    }
+                    boueesPosees[i] = couleurPince;
                     rs.pinceArriere(i, null);
                 }
+            }
+
+            if (couleurChenal == ECouleurBouee.ROUGE) {
+                group.deposeGrandChenalRouge(GrandChenaux.Line.A, boueesPosees);
+            } else {
+                group.deposeGrandChenalVert(GrandChenaux.Line.A, boueesPosees);
             }
 
         } else {
             deposeTable(null);
 
             if (couleurChenal == ECouleurBouee.ROUGE) {
-                group.deposeGrandChenalRouge(rs.pincesArriere());
+                group.deposeGrandChenalRouge(GrandChenaux.Line.A, rs.pincesArriere());
             } else {
-                group.deposeGrandChenalVert(rs.pincesArriere());
+                group.deposeGrandChenalVert(GrandChenaux.Line.A, rs.pincesArriere());
             }
             rs.clearPincesArriere();
         }

--- a/nerell-parent/nerell-common/src/main/java/org/arig/robot/services/AbstractNerellPincesAvantService.java
+++ b/nerell-parent/nerell-common/src/main/java/org/arig/robot/services/AbstractNerellPincesAvantService.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.arig.robot.constants.IConstantesNerellConfig;
 import org.arig.robot.model.ECouleurBouee;
+import org.arig.robot.model.GrandChenaux;
 import org.arig.robot.model.NerellRobotStatus;
 import org.arig.robot.system.pathfinding.IPathFinder;
 import org.arig.robot.utils.ThreadUtils;
@@ -42,18 +43,21 @@ public abstract class AbstractNerellPincesAvantService implements INerellPincesA
         servosService.ascenseursAvantBas(true);
 
         if (partielle) {
+            ECouleurBouee[] boueesPosees = new ECouleurBouee[]{null, null, null, null};
             for (int i = 0; i < 4; i++) {
                 final ECouleurBouee couleurPince = rs.pincesAvant()[i];
                 if (couleurPince == couleurChenal || couleurPince == ECouleurBouee.INCONNU) {
                     releasePompe(i);
 
-                    if (couleurChenal == ECouleurBouee.ROUGE) {
-                        group.deposeGrandChenalRouge(couleurPince);
-                    } else {
-                        group.deposeGrandChenalVert(couleurPince);
-                    }
+                    boueesPosees[i] = couleurChenal;
                     rs.pinceAvant(i, null);
                 }
+            }
+
+            if (couleurChenal == ECouleurBouee.ROUGE) {
+                group.deposeGrandChenalRouge(GrandChenaux.Line.B, boueesPosees);
+            } else {
+                group.deposeGrandChenalVert(GrandChenaux.Line.B, boueesPosees);
             }
 
             ThreadUtils.sleep(IConstantesNerellConfig.WAIT_POMPES);
@@ -63,12 +67,14 @@ public abstract class AbstractNerellPincesAvantService implements INerellPincesA
             ThreadUtils.sleep(IConstantesNerellConfig.WAIT_POMPES);
 
             if (couleurChenal == ECouleurBouee.ROUGE) {
-                group.deposeGrandChenalRouge(rs.pincesAvant());
+                group.deposeGrandChenalRouge(GrandChenaux.Line.B, rs.pincesAvant());
             } else {
-                group.deposeGrandChenalVert(rs.pincesAvant());
+                group.deposeGrandChenalVert(GrandChenaux.Line.B, rs.pincesAvant());
             }
             rs.clearPincesAvant();
         }
+
+        ThreadUtils.sleep(IConstantesNerellConfig.WAIT_POMPES);
 
         pathFinder.setObstacles(new ArrayList<>());
 


### PR DESCRIPTION
Je ne stocke pas les vraies positions mais le remplissage de 9 emplacements connus.  
Ça ne fonctionne que si la double dépose de Nerell est active.  
Il faudra encore faire l'utilitaire qui retourne les vraies positions pour la dépose d'Odin.

![New Project](https://user-images.githubusercontent.com/41597/123521062-9d830980-d6b4-11eb-9061-6a122bd546b8.png)
